### PR TITLE
OMS-N: adb shell command to access OverlayManagerService

### DIFF
--- a/target/product/base.mk
+++ b/target/product/base.mk
@@ -108,6 +108,7 @@ PRODUCT_PACKAGES += \
     mtpd \
     ndc \
     netd \
+    om \
     ping \
     ping6 \
     platform.xml \


### PR DESCRIPTION
Add a command to communicate with the OverlayManagerService for
debugging purposes. This mirrors the am and pm commands.

This commit restores the functionality after the Nougat rebase from
Sony.

Example use:
    $ adb shell om list
    com.android.systemui
        [ ] com.test.awesome-home-button

    $ adb shell om enable com.test.awesome-home-button

    $ adb shell om list
    com.android.systemui
        [x] com.test.awesome-home-button

Co-authored-by: Martin Wallgren <martin.wallgren@sonymobile.com>
Signed-off-by: Zoran Jovanovic <zoran.jovanovic@sonymobile.com>
Change-Id: If424b8ef6052e4121902b630279c0ebaf416203c