### PR TITLE
otapackage: remove file path from md5file

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -2110,7 +2110,7 @@ CUSTOM_TARGET_PACKAGE := $(PRODUCT_OUT)/omni-$(ROM_VERSION).zip
 otapackage: $(INTERNAL_OTA_PACKAGE_TARGET)
 bacon: otapackage
 	$(hide) ln -f $(INTERNAL_OTA_PACKAGE_TARGET) $(CUSTOM_TARGET_PACKAGE)
-	$(hide) $(MD5SUM) $(CUSTOM_TARGET_PACKAGE) > $(CUSTOM_TARGET_PACKAGE).md5sum
+	$(hide) $(MD5SUM) $(CUSTOM_TARGET_PACKAGE) | cut -d ' ' -f1 > $(CUSTOM_TARGET_PACKAGE).md5sum
 	@echo -e "Package complete: $(CUSTOM_TARGET_PACKAGE)"
 
 endif    # build_ota_package


### PR DESCRIPTION
This fixes the issues with md5file, user won't have the same file path
we have.

Change-Id: I866cedc246146db475c7513ba023ffba7a7e0de9
Signed-off-by: André Pinela <sheffzor@gmail.com>